### PR TITLE
Add preview GitHub Pages deployment for pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,8 +69,20 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  deploy-preview:
+    if: github.event_name == 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy preview to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- avoid deploying pull requests to production by gating deployment job to push on main
- add separate preview deployment for pull requests

## Testing
- `npm run fmt`
- `npm run lint` *(fails: Alternative text title element cannot be empty, Unexpected any, etc.)*
- `npm run typecheck` *(fails: 'transaction' is possibly 'undefined', Property 'programRunning' does not exist, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b51a1777908333a2c428b35508feb9