### PR TITLE
Add offline PWA support

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -1,4 +1,4 @@
 {
-  "ignore": ["public/spa-github-pages.js"],
+  "ignore": ["public/spa-github-pages.js", "public/service-worker.js"],
   "ignoreDependencies": ["isbot", "@react-router/node"]
 }

--- a/app/registerServiceWorker.ts
+++ b/app/registerServiceWorker.ts
@@ -1,0 +1,9 @@
+export function registerServiceWorker(): void {
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", () => {
+      navigator.serviceWorker.register("/service-worker.js").catch((err) => {
+        console.error("Service worker registration failed", err);
+      });
+    });
+  }
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Provider as JotaiProvider } from "jotai";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   isRouteErrorResponse,
   Links,
@@ -16,6 +16,7 @@ import faviconUrl from "./assets/favicon.svg?url";
 import socialShareUrl from "./assets/social-share.png?url";
 import { ServiceEventSync } from "./components/ServiceEventSync";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import { registerServiceWorker } from "./registerServiceWorker";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -29,6 +30,7 @@ export const links: Route.LinksFunction = () => [
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
   { rel: "icon", href: faviconUrl, type: "image/svg+xml" },
+  { rel: "manifest", href: "/manifest.json" },
 ];
 
 export function Layout({ children }: { children: React.ReactNode }) {
@@ -37,6 +39,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
 
         {/* Primary meta tags */}
         <title>
@@ -113,6 +116,10 @@ export default function App() {
         },
       }),
   );
+
+  useEffect(() => {
+    registerServiceWorker();
+  }, []);
 
   return (
     <JotaiProvider>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Pybricks Pilot",
+  "short_name": "Pybricks",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'pybricks-pilot-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/favicon.ico',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((cached) => cached || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest and basic service worker caching so app can work offline and be installable as a PWA
- register service worker at startup and include manifest link and theme color in document head
- ignore service worker in knip config

## Testing
- `npm run fmt`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bc1b5433f48333b4a2003a72be71fa