### PR TITLE
feat: add mission recorder for step commands

### DIFF
--- a/app/components/AddMissionDialog.tsx
+++ b/app/components/AddMissionDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useMissionManager } from "../hooks/useMissionManager";
 
 /**
@@ -17,6 +17,8 @@ export function AddMissionDialog() {
   const [description, setDescription] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState("");
+  const closeTitleId = useId();
+  const loadingTitleId = useId();
 
   // Reset form when dialog opens/closes
   useEffect(() => {
@@ -112,7 +114,10 @@ export function AddMissionDialog() {
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              role="img"
+              aria-labelledby={closeTitleId}
             >
+              <title id={closeTitleId}>Close dialog</title>
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -183,7 +188,10 @@ export function AddMissionDialog() {
                     className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
                     fill="none"
                     viewBox="0 0 24 24"
+                    role="img"
+                    aria-labelledby={loadingTitleId}
                   >
+                    <title id={loadingTitleId}>Loading</title>
                     <circle
                       cx="12"
                       cy="12"

--- a/app/components/CompactRobotController.tsx
+++ b/app/components/CompactRobotController.tsx
@@ -1,7 +1,10 @@
 import { useAtom, useAtomValue } from "jotai";
 import { useEffect, useRef, useState } from "react";
 import { useJotaiGameMat } from "../hooks/useJotaiGameMat";
+import { missionRecorder } from "../services/missionRecorder";
+import type { StepCommand } from "../types/missionRecorder";
 import { telemetryHistory } from "../services/telemetryHistory";
+import type { TelemetryData } from "../services/pybricksHub";
 import {
   perpendicularPreviewAtom,
   robotPositionAtom,
@@ -11,10 +14,13 @@ import {
 import { isUploadingProgramAtom } from "../store/atoms/hubConnection";
 import { isProgramRunningAtom } from "../store/atoms/programRunning";
 import { robotConfigAtom } from "../store/atoms/robotConfigSimplified";
+import type { PythonFile } from "../types/fileSystem";
+import type { PerpendicularPreviewGhost } from "../store/atoms/gameMat";
 import type { RobotPosition } from "../utils/robotPosition";
 import { ControlModeToggle } from "./ControlModeToggle";
 import { ManualControls } from "./ManualControls";
 import { MissionControls } from "./MissionControls";
+import { MissionRecorderControls } from "./MissionRecorderControls";
 import { MotorControls } from "./MotorControls";
 import {
   calculatePreviewPosition,
@@ -35,8 +41,8 @@ interface CompactRobotControllerProps {
   ) => Promise<void>;
   onContinuousMotorCommand?: (motor: string, speed: number) => Promise<void>;
   onMotorStopCommand?: (motor: string) => Promise<void>;
-  onExecuteCommandSequence?: (commands: any[]) => Promise<void>;
-  telemetryData?: any;
+  onExecuteCommandSequence?: (commands: StepCommand[]) => Promise<void>;
+  telemetryData?: TelemetryData;
   isConnected: boolean;
   className?: string;
   // Robot position now comes from Jotai atoms
@@ -45,9 +51,9 @@ interface CompactRobotControllerProps {
   // Program control props
   onStopProgram?: () => Promise<void>;
   onUploadAndRunFile?: (
-    file: any,
+    file: PythonFile,
     content: string,
-    allPrograms: any[],
+    allPrograms: PythonFile[],
   ) => Promise<void>;
   onPreviewUpdate?: (preview: {
     type: "drive" | "turn" | null;
@@ -90,7 +96,7 @@ export function CompactRobotController({
   onMotorCommand,
   onContinuousMotorCommand,
   onMotorStopCommand,
-  onExecuteCommandSequence,
+  onExecuteCommandSequence: _onExecuteCommandSequence,
   telemetryData,
   isConnected,
   className = "",
@@ -127,14 +133,7 @@ export function CompactRobotController({
   );
 
   // Game mat state
-  const {
-    controlMode,
-    setControlMode,
-    currentSplinePath,
-    splinePaths,
-    enterSplinePathMode,
-    exitSplinePathMode,
-  } = useJotaiGameMat();
+  const { controlMode, setControlMode } = useJotaiGameMat();
 
   // Effect to initialize trajectory overlay when enabled
   useEffect(() => {
@@ -154,7 +153,7 @@ export function CompactRobotController({
     ) {
       // Only update if there are no hover ghosts currently
       setPerpendicularPreview((prev) => {
-        const hasHoverGhosts = prev.ghosts.some((g: any) => g.isHover);
+        const hasHoverGhosts = prev.ghosts.some((g) => g.isHover);
         if (hasHoverGhosts) {
           // Don't update trajectory ghosts if there are hover ghosts
           return prev;
@@ -284,7 +283,7 @@ export function CompactRobotController({
       setPerpendicularPreview((prev) => {
         // If all current ghosts are trajectory overlay ghosts, clear them
         const hasOnlyTrajectoryGhosts = prev.ghosts.every(
-          (ghost) => (ghost as any).isTrajectoryOverlay,
+          (ghost) => ghost.isTrajectoryOverlay === true,
         );
         if (hasOnlyTrajectoryGhosts && prev.ghosts.length > 0) {
           return {
@@ -320,7 +319,7 @@ export function CompactRobotController({
     : [];
 
   // Helper functions for continuous control
-  function queueCommand(commandFn: () => Promise<any>) {
+  function queueCommand(commandFn: () => Promise<void>) {
     if (!isFullyConnected) {
       console.warn(
         "Robot controls disabled: Hub not connected or control code not loaded",
@@ -363,6 +362,11 @@ export function CompactRobotController({
 
     try {
       await onDriveCommand?.(distance, speed);
+      missionRecorder.record({
+        type: "drive",
+        distance,
+        speed,
+      });
     } finally {
       setExecutingCommand(null);
     }
@@ -385,6 +389,11 @@ export function CompactRobotController({
 
     try {
       await onTurnCommand?.(angle, speed);
+      missionRecorder.record({
+        type: "turn",
+        angle,
+        speed,
+      });
     } finally {
       setExecutingCommand(null);
     }
@@ -642,7 +651,7 @@ export function CompactRobotController({
           show: true,
           ghosts: [
             ...perpendicularPreview.ghosts.filter(
-              (g: any) =>
+              (g: PerpendicularPreviewGhost) =>
                 // Remove any previous hover ghost (identified by isHover flag)
                 // Don't remove trajectory overlay ghosts, we want both turn ghosts visible
                 !g.isHover,
@@ -676,7 +685,9 @@ export function CompactRobotController({
         // Keep the trajectory overlay ghosts, just remove hover ghosts
         setPerpendicularPreview((prev) => ({
           ...prev,
-          ghosts: prev.ghosts.filter((g: any) => !g.isHover),
+          ghosts: prev.ghosts.filter(
+            (g: PerpendicularPreviewGhost) => !g.isHover,
+          ),
         }));
       } else {
         // Clear all ghosts when not hovering and trajectory overlay is off
@@ -766,7 +777,6 @@ export function CompactRobotController({
                   driveSpeed={driveSpeed}
                   setDriveSpeed={setDriveSpeed}
                   executingCommand={executingCommand}
-                  isFullyConnected={isFullyConnected}
                   onUpdatePreview={updatePreview}
                   onUpdateDualPreview={updateDualPreview}
                   onSendStepDrive={sendStepDrive}
@@ -795,6 +805,12 @@ export function CompactRobotController({
                   onSendMotorCommand={sendMotorCommand}
                   onStartContinuousMotor={startContinuousMotor}
                   onStopContinuousMotor={stopContinuousMotor}
+                />
+
+                {/* Mission Recorder */}
+                <MissionRecorderControls
+                  onDrive={sendStepDrive}
+                  onTurn={sendStepTurn}
                 />
               </div>
             )}

--- a/app/components/DebugPanel.tsx
+++ b/app/components/DebugPanel.tsx
@@ -71,12 +71,12 @@ export function DebugPanel({ isVisible, onToggle }: DebugPanelProps) {
     }
   };
 
-  const toggleEventExpansion = (index: number) => {
+  const toggleEventExpansion = (timestamp: number) => {
     const newExpanded = new Set(expandedEvents);
-    if (newExpanded.has(index)) {
-      newExpanded.delete(index);
+    if (newExpanded.has(timestamp)) {
+      newExpanded.delete(timestamp);
     } else {
-      newExpanded.add(index);
+      newExpanded.add(timestamp);
     }
     setExpandedEvents(newExpanded);
   };
@@ -257,19 +257,22 @@ export function DebugPanel({ isVisible, onToggle }: DebugPanelProps) {
           </div>
         ) : (
           <div className="space-y-1">
-            {debugEvents.map((event, index) => {
-              const isExpanded = expandedEvents.has(index);
+            {debugEvents.map((event) => {
+              const isExpanded = expandedEvents.has(event.timestamp);
               const hasDetails =
                 event.details && Object.keys(event.details).length > 0;
 
               return (
                 <div
-                  key={index}
+                  key={event.timestamp}
                   className="border border-gray-200 dark:border-gray-600 rounded-lg p-2 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
-                  <div
-                    className={`flex items-start gap-2 ${hasDetails ? "cursor-pointer" : ""}`}
-                    onClick={() => hasDetails && toggleEventExpansion(index)}
+                  <button
+                    type="button"
+                    className={`flex items-start gap-2 w-full text-left ${hasDetails ? "cursor-pointer" : ""}`}
+                    onClick={() =>
+                      hasDetails && toggleEventExpansion(event.timestamp)
+                    }
                   >
                     <span className="text-gray-400 dark:text-gray-500 text-[10px] min-w-[60px] font-mono">
                       {formatTimestamp(event.timestamp)}
@@ -296,28 +299,29 @@ export function DebugPanel({ isVisible, onToggle }: DebugPanelProps) {
                         ▶
                       </span>
                     )}
-                  </div>
+                  </button>
 
                   {hasDetails && isExpanded && (
                     <div className="mt-2 ml-[134px] text-[9px] text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 p-2 rounded border border-gray-200 dark:border-gray-600">
                       <div className="font-mono space-y-1">
-                        {Object.entries(formatDetails(event.details!)).map(
-                          ([key, value]) => (
-                            <div
-                              key={key}
-                              className="border-b border-gray-200 dark:border-gray-600 pb-1 last:border-b-0"
-                            >
-                              <div className="text-gray-500 dark:text-gray-400 font-semibold mb-1">
-                                {key}:
+                        {event.details &&
+                          Object.entries(formatDetails(event.details)).map(
+                            ([key, value]) => (
+                              <div
+                                key={key}
+                                className="border-b border-gray-200 dark:border-gray-600 pb-1 last:border-b-0"
+                              >
+                                <div className="text-gray-500 dark:text-gray-400 font-semibold mb-1">
+                                  {key}:
+                                </div>
+                                <div className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap break-all">
+                                  {value.length > 500
+                                    ? `${value.slice(0, 500)}...`
+                                    : value}
+                                </div>
                               </div>
-                              <div className="text-gray-800 dark:text-gray-200 whitespace-pre-wrap break-all">
-                                {value.length > 500
-                                  ? `${value.slice(0, 500)}...`
-                                  : value}
-                              </div>
-                            </div>
-                          ),
-                        )}
+                            ),
+                          )}
                       </div>
                     </div>
                   )}

--- a/app/components/GameMatEditor/ChoiceEditor.tsx
+++ b/app/components/GameMatEditor/ChoiceEditor.tsx
@@ -6,7 +6,6 @@ import type {
 interface ChoiceEditorProps {
   choice: MissionObjectiveChoice;
   choiceIndex: number;
-  choices: MissionObjectiveChoice[];
   onUpdateChoice: (
     choiceIndex: number,
     updatedChoice: MissionObjectiveChoice,
@@ -18,7 +17,6 @@ interface ChoiceEditorProps {
 export function ChoiceEditor({
   choice,
   choiceIndex,
-  choices,
   onUpdateChoice,
   onRemoveChoice,
   canRemove,

--- a/app/components/ManualControls.tsx
+++ b/app/components/ManualControls.tsx
@@ -15,7 +15,6 @@ interface ManualControlsProps {
   driveSpeed: number;
   setDriveSpeed: (speed: number) => void;
   executingCommand: ExecutingCommand | null;
-  isFullyConnected: boolean;
   onUpdatePreview: (
     type: "drive" | "turn" | null,
     direction: "forward" | "backward" | "left" | "right" | null,
@@ -48,7 +47,6 @@ export function ManualControls({
   driveSpeed,
   setDriveSpeed,
   executingCommand,
-  isFullyConnected,
   onUpdatePreview,
   onUpdateDualPreview,
   onSendStepDrive,

--- a/app/components/MissionRecorderControls.tsx
+++ b/app/components/MissionRecorderControls.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { missionRecorder } from "../services/missionRecorder";
+import { missionsAtom, addMissionAtom, updateMissionAtom } from "../store/atoms/missionPlanner";
+import { robotPositionAtom } from "../store/atoms/gameMat";
+import type { StepCommand } from "../types/missionRecorder";
+import type { RobotPosition } from "../utils/robotPosition";
+
+interface MissionRecorderControlsProps {
+  onDrive: (distance: number, speed: number) => Promise<void>;
+  onTurn: (angle: number, speed: number) => Promise<void>;
+}
+
+export function MissionRecorderControls({ onDrive, onTurn }: MissionRecorderControlsProps) {
+  const [, forceUpdate] = useState(0);
+  const missions = useAtomValue(missionsAtom);
+  const addMission = useSetAtom(addMissionAtom);
+  const updateMission = useSetAtom(updateMissionAtom);
+  const currentPosition = useAtomValue(robotPositionAtom);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => missionRecorder.subscribe(() => forceUpdate((v) => v + 1)), []);
+
+  const isRecording = missionRecorder.isRecording();
+  const checkpoints = missionRecorder.getCheckpoints();
+
+  const handleStart = () => {
+    let missionId = selectedId;
+    if (!missionId && newName) {
+      const mission = addMission({
+        name: newName,
+        description: "",
+        points: [],
+        segments: [],
+        defaultArcRadius: 100,
+        steps: [],
+      });
+      missionId = mission.id;
+      setSelectedId(mission.id);
+    }
+    if (!missionId) return;
+    missionRecorder.start(missionId, currentPosition, handleUpdate);
+  };
+
+  const handleStop = () => {
+    missionRecorder.stop();
+  };
+
+  const handleUpdate = (missionId: string, points: RobotPosition[], steps: StepCommand[]) => {
+    const missionPoints = points.map((p, idx) => ({
+      id: `cp-${idx}`,
+      type: "action" as const,
+      x: p.x,
+      y: p.y,
+      heading: p.heading,
+    }));
+    const segments = missionPoints.slice(1).map((pt, i) => ({
+      fromPoint: missionPoints[i],
+      toPoint: pt,
+    }));
+    updateMission(missionId, { points: missionPoints, segments, steps });
+  };
+
+  const handlePlay = async () => {
+    const mission = missions.find((m) => m.id === selectedId);
+    if (!mission?.steps) return;
+    for (const step of mission.steps) {
+      if (step.type === "drive") {
+        await onDrive(step.distance, step.speed);
+      } else {
+        await onTurn(step.angle, step.speed);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-semibold text-gray-700 dark:text-gray-300">Mission Recorder</div>
+      {!isRecording ? (
+        <div className="flex items-center gap-2">
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="flex-1 px-2 py-1 text-xs border rounded-md dark:bg-gray-700"
+          >
+            <option value="">Select mission</option>
+            {missions.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+          <input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Or new mission"
+            className="flex-1 px-2 py-1 text-xs border rounded-md dark:bg-gray-700"
+          />
+          <button
+            type="button"
+            onClick={handleStart}
+            className="px-3 py-1 text-xs bg-green-600 text-white rounded-md"
+          >
+            Start
+          </button>
+          <button
+            type="button"
+            onClick={handlePlay}
+            disabled={!selectedId}
+            className="px-3 py-1 text-xs bg-purple-600 text-white rounded-md disabled:opacity-50"
+          >
+            Play
+          </button>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-600 dark:text-gray-400">
+            Checkpoints: {checkpoints.length}
+          </span>
+          <button
+            type="button"
+            onClick={handleStop}
+            className="px-3 py-1 text-xs bg-blue-600 text-white rounded-md"
+          >
+            Stop
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/services/missionRecorder.ts
+++ b/app/services/missionRecorder.ts
@@ -1,0 +1,93 @@
+import { calculatePreviewPosition } from "../components/MovementPreview";
+import type { RobotPosition } from "../utils/robotPosition";
+import type { StepCommand } from "../types/missionRecorder";
+
+type UpdateCallback = (missionId: string, checkpoints: RobotPosition[], steps: StepCommand[]) => void;
+
+class MissionRecorderService {
+  private recording: {
+    missionId: string;
+    checkpoints: RobotPosition[];
+    steps: StepCommand[];
+    update: UpdateCallback;
+  } | null = null;
+
+  private listeners: (() => void)[] = [];
+
+  start(missionId: string, startPosition: RobotPosition, update: UpdateCallback) {
+    this.recording = {
+      missionId,
+      checkpoints: [startPosition],
+      steps: [],
+      update,
+    };
+    update(missionId, this.recording.checkpoints, this.recording.steps);
+    this.notify();
+  }
+
+  stop() {
+    this.recording = null;
+    this.notify();
+  }
+
+  record(step: StepCommand) {
+    if (!this.recording) return;
+    const last = this.recording.checkpoints[this.recording.checkpoints.length - 1];
+    const { missionId, checkpoints, steps, update } = this.recording;
+    const direction =
+      step.type === "drive"
+        ? step.distance >= 0
+          ? "forward"
+          : "backward"
+        : step.angle >= 0
+          ? "right"
+          : "left";
+    const distance = step.type === "drive" ? Math.abs(step.distance) : 0;
+    const angle = step.type === "turn" ? Math.abs(step.angle) : 0;
+    const newPos = calculatePreviewPosition(
+      last,
+      distance,
+      angle,
+      step.type,
+      direction as any,
+    );
+
+    const lastPos = checkpoints[checkpoints.length - 1];
+    const samePlace =
+      Math.hypot(newPos.x - lastPos.x, newPos.y - lastPos.y) < 1;
+    if (samePlace) {
+      // just update heading
+      lastPos.heading = newPos.heading;
+    } else {
+      checkpoints.push(newPos);
+    }
+    steps.push(step);
+    update(missionId, checkpoints, steps);
+    this.notify();
+  }
+
+  getCheckpoints(): RobotPosition[] {
+    return this.recording ? this.recording.checkpoints : [];
+  }
+
+  getSteps(): StepCommand[] {
+    return this.recording ? this.recording.steps : [];
+  }
+
+  isRecording(): boolean {
+    return this.recording !== null;
+  }
+
+  subscribe(listener: () => void) {
+    this.listeners.push(listener);
+    return () => {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    };
+  }
+
+  private notify() {
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const missionRecorder = new MissionRecorderService();

--- a/app/store/atoms/gameMat.ts
+++ b/app/store/atoms/gameMat.ts
@@ -142,12 +142,14 @@ export const totalScoreAtom = atom<number>(0);
 export const movementPreviewAtom = atom<MovementPreview | null>(null);
 
 // Perpendicular motion preview atom - for showing all 4 possible movement options
-interface PerpendicularPreviewGhost {
+export interface PerpendicularPreviewGhost {
   position: RobotPosition;
   type: "drive" | "turn";
   direction: "forward" | "backward" | "left" | "right";
   color: string; // CSS color for the ghost robot
   label: string; // Description for the movement
+  isHover?: boolean;
+  isTrajectoryOverlay?: boolean;
 }
 
 export const perpendicularPreviewAtom = atom<{

--- a/app/types/missionPlanner.ts
+++ b/app/types/missionPlanner.ts
@@ -2,6 +2,8 @@
  * Mission Planner types and interfaces
  */
 
+import type { StepCommand } from "./missionRecorder";
+
 // Base point interface for waypoints and actions (have explicit coordinates)
 interface MissionPoint {
   id: string;
@@ -82,6 +84,7 @@ export interface Mission {
   defaultArcRadius: number; // default arc radius for segments without specific config
   created: string; // ISO date string
   modified: string; // ISO date string
+  steps?: StepCommand[];
 }
 
 // Mission execution command types

--- a/app/types/missionRecorder.ts
+++ b/app/types/missionRecorder.ts
@@ -1,0 +1,4 @@
+export type StepCommand =
+  | { type: "drive"; distance: number; speed: number }
+  | { type: "turn"; angle: number; speed: number };
+

--- a/app/utils/canvas/splinePathDrawing.ts
+++ b/app/utils/canvas/splinePathDrawing.ts
@@ -1,12 +1,6 @@
 import type { SplinePath } from "../../store/atoms/gameMat";
 import type { RobotDrawingUtils } from "./robotDrawing";
 
-interface SplinePathDrawingProps {
-  splinePath: SplinePath;
-  selectedPointId?: string | null;
-  utils: RobotDrawingUtils;
-}
-
 /**
  * Draw a spline path with its points and connections
  */

--- a/app/utils/missionPointResolver.ts
+++ b/app/utils/missionPointResolver.ts
@@ -1,5 +1,6 @@
 import type { NamedPosition } from "../store/atoms/positionManagement";
 import type {
+  ActionPoint,
   EndPoint,
   MissionPointType,
   ResolvedMissionPoint,
@@ -60,8 +61,8 @@ function resolveMissionPoint(
     type: point.type,
     // Include additional properties for actions
     ...(point.type === "action" && {
-      actionName: (point as any).actionName,
-      pauseDuration: (point as any).pauseDuration,
+      actionName: (point as ActionPoint).actionName,
+      pauseDuration: (point as ActionPoint).pauseDuration,
     }),
   };
 }

--- a/app/utils/robotPosition.ts
+++ b/app/utils/robotPosition.ts
@@ -49,7 +49,6 @@ export function calculateRobotPositionFromEdges(
   const matHeightMm = matConfig?.dimensions?.heightMm || 1137;
 
   let x: number;
-  let y: number;
 
   if (side === "left") {
     // fromSideMm is distance from left edge to the left edge of robot
@@ -60,7 +59,8 @@ export function calculateRobotPositionFromEdges(
   }
 
   // fromBottomMm is distance from bottom edge to the bottom edge of robot
-  y = matHeightMm - fromBottomMm - (robotLengthMm - centerOfRotationFromTopMm);
+  const y =
+    matHeightMm - fromBottomMm - (robotLengthMm - centerOfRotationFromTopMm);
 
   const result = {
     x,


### PR DESCRIPTION
## Summary
- link mission recorder with mission planner and dedupe checkpoint rotations
- allow selecting or creating missions while recording and replay recorded steps
- extend mission type to store recorded step commands

## Testing
- `npm run lint` *(fails: Static elements and unused variables across unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68b50ae727948333b6534a78cfaf175b