### PR TITLE
Ignore drivebase motors when generating pseudo code

### DIFF
--- a/app/assets/pybrickspilot.py
+++ b/app/assets/pybrickspilot.py
@@ -642,7 +642,7 @@ async def _execute_single_command(command):
                 _drivebase.reset()
                 _hub.imu.reset_heading(0)
                 for motor in _motors:
-                    motor.reset_angle(0)
+                    _motors[motor].reset_angle(0)
                 print("[PILOT] Drivebase telemetry reset - distance and angle set to 0")
             except Exception as e:
                 print("[PILOT] Drivebase reset error:", e)

--- a/app/assets/pybrickspilot.py
+++ b/app/assets/pybrickspilot.py
@@ -641,6 +641,8 @@ async def _execute_single_command(command):
             try:
                 _drivebase.reset()
                 _hub.imu.reset_heading(0)
+                for motor in _motors:
+                    motor.reset_angle(0)
                 print("[PILOT] Drivebase telemetry reset - distance and angle set to 0")
             except Exception as e:
                 print("[PILOT] Drivebase reset error:", e)

--- a/app/components/ProgramControls.tsx
+++ b/app/components/ProgramControls.tsx
@@ -188,6 +188,24 @@ export function ProgramControls({
     }
   }, [programOutputLog?.length]);
 
+  useEffect(() => {
+    const handleRobotAlert = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        code?: string;
+        message?: string;
+      }>).detail;
+      if (!detail) return;
+      const label = detail.code ? `${detail.code}: ${detail.message ?? ""}` : detail.message;
+      if (!label) return;
+      setLastUploadError(label.trim());
+    };
+
+    document.addEventListener("robotAlert", handleRobotAlert as EventListener);
+    return () => {
+      document.removeEventListener("robotAlert", handleRobotAlert as EventListener);
+    };
+  }, []);
+
   const handleUploadAndRunMenu = async () => {
     if (allPrograms.length > 0 && uploadAndRunHubMenu) {
       try {
@@ -286,15 +304,25 @@ export function ProgramControls({
       </div>
       {lastUploadError && (
         <div className="mt-2 text-xs p-2 rounded border border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20 text-red-700 dark:text-red-300 flex items-center justify-between gap-2">
-          <span className="truncate">{lastUploadError}</span>
-          <button
-            type="button"
-            onClick={() => openDetails(true)}
-            className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700"
-            title="Open Debug details"
-          >
-            View details
-          </button>
+          <span className="truncate pr-2">{lastUploadError}</span>
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              type="button"
+              onClick={() => openDetails(true)}
+              className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700"
+              title="Open Debug details"
+            >
+              View details
+            </button>
+            <button
+              type="button"
+              onClick={() => setLastUploadError(null)}
+              className="px-2 py-1 text-xs bg-gray-200 text-gray-700 rounded hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              title="Dismiss this error"
+            >
+              Dismiss
+            </button>
+          </div>
         </div>
       )}
       {lastUploadError && (

--- a/app/components/TelemetryDashboard.tsx
+++ b/app/components/TelemetryDashboard.tsx
@@ -48,6 +48,7 @@ import { ProgramOutputLog } from "./ProgramOutputLog";
 import { RobotBuilder } from "./RobotBuilder";
 import { RobotControlsSection } from "./RobotControlsSection";
 import { SensorDisplay } from "./SensorDisplay";
+import { telemetryHistory } from "../services/telemetryHistory";
 
 // Load built-in maps using the same logic as MapSelector
 const seasonConfigs = import.meta.glob("../assets/seasons/**/config.json", {
@@ -132,6 +133,7 @@ export function TelemetryDashboard({ className = "" }: { className?: string }) {
     clearProgramOutputLog,
     // Unused in this component: motors/program controls handled elsewhere
     uploadAndRunHubMenu,
+    resetTelemetry,
   } = robotConnection;
 
   // Get file system data for program list
@@ -154,6 +156,19 @@ export function TelemetryDashboard({ className = "" }: { className?: string }) {
         "programs",
       );
       await uploadAndRunHubMenu(allPrograms, pythonFiles);
+
+      if (typeof resetTelemetry === "function") {
+        try {
+          await resetTelemetry(false);
+        } catch (error) {
+          console.warn(
+            "[TelemetryDashboard] Failed to reset telemetry after Up&Run:",
+            error,
+          );
+        }
+      }
+
+      telemetryHistory.onMatReset();
     } else {
       throw new Error("No upload method available");
     }

--- a/app/hooks/usePybricksHubEventManager.ts
+++ b/app/hooks/usePybricksHubEventManager.ts
@@ -77,6 +77,32 @@ export function usePybricksHubEventManager() {
 
         // Check for hub menu status messages
         const output = normalized;
+        if (output.includes("[PILOT:ALERT]")) {
+          try {
+            const alertText = output.split("[PILOT:ALERT]").pop()?.trim() || "";
+            let code: string | undefined;
+            let message: string = alertText;
+
+            const match = alertText.match(/([^:]+):\s*(.*)/);
+            if (match) {
+              code = match[1].trim();
+              message = match[2].trim();
+            }
+
+            const alertEvent = new CustomEvent("robotAlert", {
+              detail: {
+                code: code || "ALERT",
+                message,
+                raw: output,
+                timestamp: Date.now(),
+              },
+            });
+            document.dispatchEvent(alertEvent);
+          } catch (error) {
+            console.warn("Failed to parse pilot alert:", output, error);
+          }
+        }
+
         if (output.includes("[PILOT:MENU_STATUS]")) {
           try {
             // Parse hub menu status: [PILOT:MENU_STATUS] selected=1 total=3 state=menu

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -148,6 +148,7 @@ export default function Home() {
     showSuccess,
     showError,
     showInfo,
+    showWarning,
   } = useNotifications();
 
   // Robot configuration discovery
@@ -172,6 +173,34 @@ export default function Home() {
       });
     }
   }, [discoverRobotConfigs, stableDirectoryAccess]);
+
+  useEffect(() => {
+    const handleRobotAlert = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        code?: string;
+        message?: string;
+      }>).detail;
+
+      const title = detail?.code === "DRIVE_STALL" || detail?.code === "TURN_STALL"
+        ? "Robot Stall Detected"
+        : "Robot Alert";
+
+      const message = detail?.message || "The robot reported an alert condition.";
+      showWarning(title, message, 0);
+    };
+
+    document.addEventListener(
+      "robotAlert",
+      handleRobotAlert as EventListener,
+    );
+
+    return () => {
+      document.removeEventListener(
+        "robotAlert",
+        handleRobotAlert as EventListener,
+      );
+    };
+  }, [showWarning]);
 
   // Enhanced error handling with notifications
   const handleConnect = async (options: any) => {

--- a/app/services/pseudoCodeGenerator.ts
+++ b/app/services/pseudoCodeGenerator.ts
@@ -67,6 +67,22 @@ class PseudoCodeGeneratorService {
   private readonly MOTOR_START_THRESHOLD = 0.5;
   private readonly MOTOR_MIN_ANGLE_THRESHOLD = 5;
   private readonly MOTOR_STOP_SPEED_THRESHOLD = 5;
+  private readonly DRIVEBASE_MOTOR_NAMES = new Set([
+    "left",
+    "right",
+    "driveleft",
+    "driveright",
+    "leftdrive",
+    "rightdrive",
+    "leftmotor",
+    "rightmotor",
+    "leftwheel",
+    "rightwheel",
+    "drivebaseleft",
+    "drivebaseright",
+    "leftdb",
+    "rightdb",
+  ]);
   private motorAngleMode: MotorAngleMode = "relative";
 
   /**
@@ -702,10 +718,16 @@ class PseudoCodeGeneratorService {
 
     const motorCommands: MovementCommand[] = [];
     const motorNames = new Set<string>();
+    const hasDrivebaseTelemetry = telemetryPoints.some(
+      (point) => point.drivebase !== undefined,
+    );
 
     telemetryPoints.forEach((point) => {
       if (point.motors) {
         for (const name of Object.keys(point.motors)) {
+          if (hasDrivebaseTelemetry && this.isDrivebaseMotorName(name)) {
+            continue;
+          }
           motorNames.add(name);
         }
       }
@@ -832,6 +854,12 @@ class PseudoCodeGeneratorService {
       motorStartAngle: startAngle,
       motorTargetAngle: targetAngle,
     });
+  }
+
+  private isDrivebaseMotorName(name: string): boolean {
+    const normalized = name.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+    return this.DRIVEBASE_MOTOR_NAMES.has(normalized);
   }
 
   /**

--- a/app/services/pseudoCodeGenerator.ts
+++ b/app/services/pseudoCodeGenerator.ts
@@ -204,6 +204,8 @@ class PseudoCodeGeneratorService {
     }
 
     const commands: MovementCommand[] = [];
+    const motorCommands: MovementCommand[] = [];
+    const activeMotorSegments = new Map<string, MotorMovementSegment>();
     let currentCommand: MovementCommand | null = null;
     let totalDistance = 0;
     const startPosition = telemetryPoints[0];
@@ -232,6 +234,13 @@ class PseudoCodeGeneratorService {
     for (let i = 1; i < telemetryPoints.length; i++) {
       const prevPoint = telemetryPoints[i - 1];
       const currentPoint = telemetryPoints[i];
+
+      this.updateMotorSegments(
+        motorCommands,
+        activeMotorSegments,
+        prevPoint,
+        currentPoint,
+      );
 
       // Skip if we don't have drive base data
       if (!prevPoint.drivebase || !currentPoint.drivebase) {
@@ -318,8 +327,10 @@ class PseudoCodeGeneratorService {
         }
 
         // Determine the new movement type
-        const lastCommandType =
+        const rawLastCommandType =
           commands.length > 0 ? commands[commands.length - 1].type : undefined;
+        const lastCommandType =
+          rawLastCommandType === "motor" ? undefined : rawLastCommandType;
         const movementType: "drive" | "turn" | "arc" = isArc
           ? "arc"
           : this.determineMovementTypeForSwitch(
@@ -397,6 +408,10 @@ class PseudoCodeGeneratorService {
         accumulatedHeading = 0;
       }
     }
+
+    activeMotorSegments.forEach((segment, motorName) => {
+      this.finalizeMotorSegment(motorCommands, motorName, segment);
+    });
 
     // Add final command if exists
     if (currentCommand) {
@@ -486,7 +501,6 @@ class PseudoCodeGeneratorService {
       }
     }
 
-    const motorCommands = this.generateMotorCommands(telemetryPoints);
     const allCommandsWithIndex = [...commands, ...motorCommands].map(
       (command, index) => ({ command, index }),
     );
@@ -706,129 +720,121 @@ class PseudoCodeGeneratorService {
     return summarized;
   }
 
-  /**
-   * Generate pseudo code commands for individual motors from telemetry data
-   */
-  private generateMotorCommands(
-    telemetryPoints: RawTelemetryPoint[],
-  ): MovementCommand[] {
-    if (telemetryPoints.length < 2) {
-      return [];
-    }
-
-    const motorCommands: MovementCommand[] = [];
-    const motorNames = new Set<string>();
-    const hasDrivebaseTelemetry = telemetryPoints.some(
-      (point) => point.drivebase !== undefined,
-    );
-
-    telemetryPoints.forEach((point) => {
-      if (point.motors) {
-        for (const name of Object.keys(point.motors)) {
-          if (hasDrivebaseTelemetry && this.isDrivebaseMotorName(name)) {
-            continue;
-          }
-          motorNames.add(name);
-        }
-      }
-    });
+  private updateMotorSegments(
+    motorCommands: MovementCommand[],
+    activeSegments: Map<string, MotorMovementSegment>,
+    prevPoint: RawTelemetryPoint,
+    currentPoint: RawTelemetryPoint,
+  ): void {
+    const prevMotors = prevPoint.motors || {};
+    const currentMotors = currentPoint.motors || {};
+    const motorNames = new Set([
+      ...Object.keys(prevMotors),
+      ...Object.keys(currentMotors),
+    ]);
 
     motorNames.forEach((motorName) => {
-      let segment: MotorMovementSegment | null = null;
+      const prevMotor = prevMotors[motorName];
+      const currentMotor = currentMotors[motorName];
 
-      for (let i = 1; i < telemetryPoints.length; i++) {
-        const prevPoint = telemetryPoints[i - 1];
-        const currentPoint = telemetryPoints[i];
-        const prevMotor = prevPoint.motors?.[motorName];
-        const currentMotor = currentPoint.motors?.[motorName];
-
-        if (!prevMotor || !currentMotor) {
-          if (segment) {
-            this.finalizeMotorSegment(motorCommands, motorName, segment);
-            segment = null;
-          }
-          continue;
+      if (!prevMotor || !currentMotor) {
+        const existing = activeSegments.get(motorName);
+        if (existing) {
+          this.finalizeMotorSegment(motorCommands, motorName, existing);
+          activeSegments.delete(motorName);
         }
-
-        const timeDelta = currentPoint.timestamp - prevPoint.timestamp;
-        const delta = currentMotor.angle - prevMotor.angle;
-
-        if (!segment) {
-          if (Math.abs(delta) >= this.MOTOR_START_THRESHOLD) {
-            segment = {
-              startAngle: prevMotor.angle,
-              startTimestamp: prevPoint.timestamp,
-              accumulatedDelta: delta,
-              duration: timeDelta,
-              lastAngle: currentMotor.angle,
-              lastTimestamp: currentPoint.timestamp,
-              isCmdKeyPressed:
-                prevPoint.isCmdKeyPressed || currentPoint.isCmdKeyPressed,
-            };
-          }
-          continue;
-        }
-
-        const prevAccumulated = segment.accumulatedDelta;
-        const prevSign = Math.sign(prevAccumulated);
-        const deltaSign = Math.sign(delta);
-        const directionChanged =
-          prevSign !== 0 && deltaSign !== 0 && prevSign !== deltaSign;
-
-        if (directionChanged) {
-          if (Math.abs(prevAccumulated) >= this.MOTOR_MIN_ANGLE_THRESHOLD) {
-            this.finalizeMotorSegment(motorCommands, motorName, segment);
-          }
-
-          segment =
-            Math.abs(delta) >= this.MOTOR_START_THRESHOLD
-              ? {
-                  startAngle: prevMotor.angle,
-                  startTimestamp: prevPoint.timestamp,
-                  accumulatedDelta: delta,
-                  duration: timeDelta,
-                  lastAngle: currentMotor.angle,
-                  lastTimestamp: currentPoint.timestamp,
-                  isCmdKeyPressed:
-                    prevPoint.isCmdKeyPressed || currentPoint.isCmdKeyPressed,
-                }
-              : null;
-          continue;
-        }
-
-        segment.accumulatedDelta = prevAccumulated + delta;
-        segment.duration += timeDelta;
-        segment.lastAngle = currentMotor.angle;
-        segment.lastTimestamp = currentPoint.timestamp;
-        if (prevPoint.isCmdKeyPressed || currentPoint.isCmdKeyPressed) {
-          segment.isCmdKeyPressed = true;
-        }
-
-        const approxSpeed =
-          currentMotor.speed !== undefined
-            ? Math.abs(currentMotor.speed)
-            : timeDelta > 0
-              ? Math.abs(delta) / Math.max(timeDelta / 1000, 1e-6)
-              : 0;
-        const smallDelta = Math.abs(delta) < this.MOTOR_START_THRESHOLD;
-        const shouldFinalize =
-          Math.abs(segment.accumulatedDelta) >=
-            this.MOTOR_MIN_ANGLE_THRESHOLD &&
-          approxSpeed <= this.MOTOR_STOP_SPEED_THRESHOLD &&
-          smallDelta;
-
-        if (shouldFinalize) {
-          this.finalizeMotorSegment(motorCommands, motorName, segment);
-          segment = null;
-        }
+        return;
       }
 
-      if (segment) {
+      const isDrivebaseMotor = this.isDrivebaseMotorName(motorName);
+      if (
+        isDrivebaseMotor &&
+        prevPoint.drivebase !== undefined &&
+        currentPoint.drivebase !== undefined
+      ) {
+        const existing = activeSegments.get(motorName);
+        if (existing) {
+          this.finalizeMotorSegment(motorCommands, motorName, existing);
+          activeSegments.delete(motorName);
+        }
+        return;
+      }
+
+      const timeDelta = currentPoint.timestamp - prevPoint.timestamp;
+      const delta = currentMotor.angle - prevMotor.angle;
+
+      let segment = activeSegments.get(motorName) || null;
+
+      if (!segment) {
+        if (Math.abs(delta) >= this.MOTOR_START_THRESHOLD) {
+          segment = {
+            startAngle: prevMotor.angle,
+            startTimestamp: prevPoint.timestamp,
+            accumulatedDelta: delta,
+            duration: timeDelta,
+            lastAngle: currentMotor.angle,
+            lastTimestamp: currentPoint.timestamp,
+            isCmdKeyPressed:
+              prevPoint.isCmdKeyPressed || currentPoint.isCmdKeyPressed,
+          };
+          activeSegments.set(motorName, segment);
+        }
+        return;
+      }
+
+      const prevAccumulated = segment.accumulatedDelta;
+      const prevSign = Math.sign(prevAccumulated);
+      const deltaSign = Math.sign(delta);
+      const directionChanged =
+        prevSign !== 0 && deltaSign !== 0 && prevSign !== deltaSign;
+
+      if (directionChanged) {
+        if (Math.abs(prevAccumulated) >= this.MOTOR_MIN_ANGLE_THRESHOLD) {
+          this.finalizeMotorSegment(motorCommands, motorName, segment);
+        }
+
+        activeSegments.delete(motorName);
+
+        if (Math.abs(delta) >= this.MOTOR_START_THRESHOLD) {
+          activeSegments.set(motorName, {
+            startAngle: prevMotor.angle,
+            startTimestamp: prevPoint.timestamp,
+            accumulatedDelta: delta,
+            duration: timeDelta,
+            lastAngle: currentMotor.angle,
+            lastTimestamp: currentPoint.timestamp,
+            isCmdKeyPressed:
+              prevPoint.isCmdKeyPressed || currentPoint.isCmdKeyPressed,
+          });
+        }
+        return;
+      }
+
+      segment.accumulatedDelta = prevAccumulated + delta;
+      segment.duration += timeDelta;
+      segment.lastAngle = currentMotor.angle;
+      segment.lastTimestamp = currentPoint.timestamp;
+      if (prevPoint.isCmdKeyPressed || currentPoint.isCmdKeyPressed) {
+        segment.isCmdKeyPressed = true;
+      }
+
+      const approxSpeed =
+        currentMotor.speed !== undefined
+          ? Math.abs(currentMotor.speed)
+          : timeDelta > 0
+            ? Math.abs(delta) / Math.max(timeDelta / 1000, 1e-6)
+            : 0;
+      const smallDelta = Math.abs(delta) < this.MOTOR_START_THRESHOLD;
+      const shouldFinalize =
+        Math.abs(segment.accumulatedDelta) >= this.MOTOR_MIN_ANGLE_THRESHOLD &&
+        approxSpeed <= this.MOTOR_STOP_SPEED_THRESHOLD &&
+        smallDelta;
+
+      if (shouldFinalize) {
         this.finalizeMotorSegment(motorCommands, motorName, segment);
+        activeSegments.delete(motorName);
       }
     });
-
-    return motorCommands;
   }
 
   private finalizeMotorSegment(


### PR DESCRIPTION
## Summary
- add canonical drivebase motor name detection so pseudo code skips left/right drive motors
- filter drivebase motors when building individual motor commands to preserve drive movement grouping

## Testing
- npm run lint *(fails: existing lint issues unrelated to this change)*
- npm run typecheck *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68deefd2ea348333a28ccf484346d5eb