### PR TITLE
Add shareable mat scoring links

### DIFF
--- a/app/components/MatControlsPanel.tsx
+++ b/app/components/MatControlsPanel.tsx
@@ -1,4 +1,5 @@
 import { useAtom, useAtomValue } from "jotai";
+import { useState } from "react";
 import { useJotaiGameMat } from "../hooks/useJotaiGameMat";
 import { hasDirectoryAccessAtom } from "../store/atoms/fileSystem";
 import { currentScoreAtom } from "../store/atoms/gameMat";
@@ -10,13 +11,14 @@ import {
   showMatEditorAtom,
   showScoringAtom,
 } from "../store/atoms/matUIState";
+import { encodeScoringState, hasScoringData } from "../utils/scoringShare";
 
 interface MatControlsPanelProps {
   onClearMat: () => void;
 }
 
 export function MatControlsPanel({ onClearMat }: MatControlsPanelProps) {
-  const { customMatConfig } = useJotaiGameMat();
+  const { customMatConfig, scoringState } = useJotaiGameMat();
   const hasDirectoryAccess = useAtomValue(hasDirectoryAccessAtom);
   const currentScore = useAtomValue(currentScoreAtom);
   const [showScoring, setShowScoring] = useAtom(showScoringAtom);
@@ -25,6 +27,49 @@ export function MatControlsPanel({ onClearMat }: MatControlsPanelProps) {
   const [, setMatEditorMode] = useAtom(matEditorModeAtom);
   const isLoadingConfig = useAtomValue(isMatConfigLoadingAtom);
   const [lowQuality, setLowQuality] = useAtom(lowQualityModeAtom);
+  const [shareStatus, setShareStatus] = useState<"idle" | "copied" | "error">(
+    "idle",
+  );
+
+  const canShareScore = hasScoringData(scoringState);
+
+  const handleShareScore = async () => {
+    if (!canShareScore || typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const encodedScore = encodeScoringState(scoringState);
+      const url = new URL(window.location.href);
+      url.searchParams.set("score", encodedScore);
+
+      if (customMatConfig?.name) {
+        url.searchParams.set("mat", customMatConfig.name);
+      } else {
+        url.searchParams.delete("mat");
+      }
+
+      const shareUrl = url.toString();
+
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(shareUrl);
+      } else {
+        const textarea = document.createElement("textarea");
+        textarea.value = shareUrl;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+      }
+
+      setShareStatus("copied");
+      window.setTimeout(() => setShareStatus("idle"), 2500);
+    } catch (error) {
+      console.error("Failed to copy scoring link", error);
+      setShareStatus("error");
+      window.setTimeout(() => setShareStatus("idle"), 3000);
+    }
+  };
 
   return (
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm">
@@ -114,6 +159,26 @@ export function MatControlsPanel({ onClearMat }: MatControlsPanelProps) {
               className="px-2 py-1.5 rounded text-xs font-medium border bg-red-50 dark:bg-red-900 border-red-300 dark:border-red-700 text-red-700 dark:text-red-300"
             >
               🧹 Clear Custom Mat
+            </button>
+            <button
+              type="button"
+              onClick={handleShareScore}
+              disabled={!canShareScore}
+              className={`col-span-2 px-2 py-1.5 rounded text-xs font-medium border flex items-center justify-center gap-2 ${
+                canShareScore
+                  ? "bg-blue-50 dark:bg-blue-900 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-200 hover:bg-blue-100 dark:hover:bg-blue-800"
+                  : "bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-400 cursor-not-allowed"
+              }`}
+            >
+              <span>🔗 Share Score</span>
+              {shareStatus === "copied" && (
+                <span className="text-green-600 dark:text-green-300">
+                  Copied!
+                </span>
+              )}
+              {shareStatus === "error" && (
+                <span className="text-red-600 dark:text-red-300">Failed</span>
+              )}
             </button>
           </div>
         )}

--- a/app/components/TelemetryDashboard.tsx
+++ b/app/components/TelemetryDashboard.tsx
@@ -49,6 +49,7 @@ import { RobotBuilder } from "./RobotBuilder";
 import { RobotControlsSection } from "./RobotControlsSection";
 import { SensorDisplay } from "./SensorDisplay";
 import { telemetryHistory } from "../services/telemetryHistory";
+import { decodeScoringState } from "../utils/scoringShare";
 
 // Load built-in maps using the same logic as MapSelector
 const seasonConfigs = import.meta.glob("../assets/seasons/**/config.json", {
@@ -178,7 +179,8 @@ export function TelemetryDashboard({ className = "" }: { className?: string }) {
   const [showMapSelector, setShowMapSelector] = useAtom(showMapSelectorAtom);
   const [matEditorMode, setMatEditorMode] = useAtom(matEditorModeAtom);
   // Use Jotai for custom mat config instead of local state
-  const { customMatConfig, setCustomMatConfig } = useJotaiGameMat();
+  const { customMatConfig, setCustomMatConfig, setScoringState } =
+    useJotaiGameMat();
   const [showScoring, setShowScoring] = useAtom(showScoringAtom);
   // Use Jotai for current score instead of local state
   // currentScore used inside MatControlsPanel via atom
@@ -212,6 +214,26 @@ export function TelemetryDashboard({ className = "" }: { className?: string }) {
     };
     loadDefaultMat();
   }, [setCustomMatConfig, setShowScoring, setIsLoadingConfig]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const encodedScore = params.get("score");
+    if (!encodedScore) {
+      return;
+    }
+
+    const sharedState = decodeScoringState(encodedScore);
+    if (!sharedState) {
+      return;
+    }
+
+    setScoringState(sharedState);
+    setShowScoring(true);
+  }, [setScoringState, setShowScoring]);
 
   useEffect(() => {
     if (currentRobotConfig && customMatConfig) {

--- a/app/utils/scoringShare.ts
+++ b/app/utils/scoringShare.ts
@@ -1,0 +1,59 @@
+import type { ScoringState } from "./scoringUtils";
+
+const toBase64 = (value: string): string => {
+  if (typeof globalThis.btoa === "function") {
+    return globalThis.btoa(value);
+  }
+
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "utf-8").toString("base64");
+  }
+
+  throw new Error("No base64 encoder available in this environment");
+};
+
+const fromBase64 = (value: string): string => {
+  if (typeof globalThis.atob === "function") {
+    return globalThis.atob(value);
+  }
+
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(value, "base64").toString("utf-8");
+  }
+
+  throw new Error("No base64 decoder available in this environment");
+};
+
+const toBase64Url = (value: string): string =>
+  toBase64(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+
+const fromBase64Url = (value: string): string => {
+  const paddedLength = (4 - (value.length % 4)) % 4;
+  const padding = "=".repeat(paddedLength);
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/") + padding;
+  return fromBase64(normalized);
+};
+
+export const encodeScoringState = (state: ScoringState): string =>
+  toBase64Url(JSON.stringify(state));
+
+export const decodeScoringState = (encoded: string): ScoringState | null => {
+  try {
+    const json = fromBase64Url(encoded);
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object") {
+      return parsed as ScoringState;
+    }
+    return null;
+  } catch (error) {
+    console.warn("Failed to decode scoring state", error);
+    return null;
+  }
+};
+
+export const hasScoringData = (state: ScoringState): boolean =>
+  Object.values(state).some((mission) =>
+    Object.values(mission?.objectives ?? {}).some((objective) =>
+      Boolean(objective?.completed),
+    ),
+  );


### PR DESCRIPTION
## Summary
- add a scoringShare utility that can encode/decode mat scoring state to URL-safe strings
- surface a "Share Score" button in the Mat Controls panel that copies a link with the current scoring data
- hydrate the scoring state from `?score=` query parameters so shared links immediately show the recorded scores

## Testing
- `npm run lint` *(fails: existing repository diagnostics in DebugDetailsModal, CompactRobotController, etc.)*
- `npm run typecheck` *(fails: existing repository type errors in CompactRobotController and useCanvasDrawing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c68e539c8333b3435d777dedb89e)